### PR TITLE
fix verbose option

### DIFF
--- a/src/pif/commands/get_public_ip.py
+++ b/src/pif/commands/get_public_ip.py
@@ -36,7 +36,7 @@ def main():
     verbose = None
 
     try:
-        verbose = bool(int(args.preferred_checker))
+        verbose = bool(int(args.verbose))
         kwargs.update({'verbose': verbose})
     except:
         pass

--- a/src/pif/utils.py
+++ b/src/pif/utils.py
@@ -45,7 +45,8 @@ def get_public_ip(preferred_checker=None, verbose=False):
         ip = ip_checker.get_public_ip()
 
         if verbose:
-            print('provider: ', ip_checker_cls)
+            #print('provider: ', ip_checker_cls)
+            print('provider: ', preferred_checker)
         return ip
 
     # Using all checkers.


### PR DESCRIPTION
actually verbose option return only ip addres (not info on checker)
as tested via
get-public-ip -c dyndns.com -v 1

fixed to work again and display checker name instead of checker class (imho more useful)
