### PR TITLE
Force list_checkers() to autodiscover checkers as it returns empty list

### DIFF
--- a/src/pif/utils.py
+++ b/src/pif/utils.py
@@ -22,6 +22,7 @@ def list_checkers():
 
     :return list:
     """
+    ensure_autodiscover()
     return registry._registry.keys()
 
 def get_public_ip(preferred_checker=None, verbose=False):


### PR DESCRIPTION
I believe that you should ensure checkers are discovered as the example you give with `list_checkers()` does not work if you just copy-paste it.
